### PR TITLE
fixed package-lock.json -

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
       "dependencies": {
         "@dwp/dwp-frontend": "2.7.0",
         "@govuk-prototype-kit/common-templates": "2.0.1",
+        "@ministryofjustice/frontend": "^2.1.0",
         "govuk-frontend": "5.4.0",
         "govuk-prototype-kit": "13.16.2"
       }
@@ -23,6 +24,21 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@govuk-prototype-kit/common-templates/-/common-templates-2.0.1.tgz",
       "integrity": "sha512-9vIluzHin4yJhMKt97P6bEW7DzCmHtBZZnCWCkFnjCJoI4HwaBwPCu1CzKhMsSoCKCE2DJsGbTu13iuHzCxVJQ=="
+    },
+    "node_modules/@ministryofjustice/frontend": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@ministryofjustice/frontend/-/frontend-2.2.0.tgz",
+      "integrity": "sha512-d6ZPTnsJC7vofU1+nPmDXzmZeYP5oYJXWTthHHf2kABQnEBMeJvTZJdxttH2qw9NjFbV5mWiPNWZsx0wgG4qvg==",
+      "dependencies": {
+        "govuk-frontend": "^5.0.0",
+        "moment": "^2.27.0"
+      },
+      "engines": {
+        "node": ">= 4.2.0"
+      },
+      "peerDependencies": {
+        "jquery": "^3.6.0"
+      }
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -1909,6 +1925,12 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
+    "node_modules/jquery": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
+      "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
+      "peer": true
+    },
     "node_modules/jsonfile": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -2063,6 +2085,14 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-1.2.0.tgz",
       "integrity": "sha512-r6lj77KlwqLhIUku9UWYes7KJtsczvolZkzp8hbaDPPaE24OmWl5s539Mytlj22siEQKosZ26qCBgda2PKwoJw=="
+    },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/ms": {
       "version": "2.0.0",


### PR DESCRIPTION
 deleted package-lock.json and ran npm install to re-install with correct packages from package.json.

Suspected issue: wrong node version. Latest version of the prototype kit requires version 16, 18 or 20.